### PR TITLE
created migration to change data type of artwork.description to text …

### DIFF
--- a/db/migrate/20210304152523_change_data_type_of_description_in_artworks.rb
+++ b/db/migrate/20210304152523_change_data_type_of_description_in_artworks.rb
@@ -1,0 +1,8 @@
+class ChangeDataTypeOfDescriptionInArtworks < ActiveRecord::Migration[6.1]
+  def change
+    change_table :artworks do |t|
+      t.remove :description
+      t.text :description
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_03_115139) do
+ActiveRecord::Schema.define(version: 2021_03_04_152523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,10 +47,10 @@ ActiveRecord::Schema.define(version: 2021_03_03_115139) do
     t.bigint "user_id", null: false
     t.string "category"
     t.string "name"
-    t.string "description"
     t.integer "rate"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "description"
     t.index ["user_id"], name: "index_artworks_on_user_id"
   end
 


### PR DESCRIPTION
created migration to change data type of artwork.description to text..
Now, when creating a new artwork, the input field for description is a little bigger and the description is not limited to 256 characters.
![image](https://user-images.githubusercontent.com/77265306/109987624-d8cd8700-7d17-11eb-9b87-a55dccdbde7d.png)
