### PR TITLE
added end_date must come after start_date validation to booking model

### DIFF
--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -19,3 +19,6 @@ class Artwork < ApplicationRecord
       tsearch: { prefix: true }
     }
 end
+
+
+

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -10,16 +10,16 @@ class Booking < ApplicationRecord
 
   def end_date_cannot_come_before_start_date
     if end_date.present? && end_date < start_date
-      errors.add(:end_date, "end date must come after start date")
+      errors.add(:end_date, "must come after start date")
     end
   end
 
   def booking_dates_cannot_be_in_the_past
     if start_date.present? && start_date < Date.today
-      errors.add(:start_date, "You cannot make a booking in the past")
+      errors.add(:start_date, "cannot be in the past")
     end
     if end_date.present? && end_date < Date.today
-      errors.add(:end_date, "You cannot make a booking in the past")
+      errors.add(:end_date, "cannot be in the past")
     end
   end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,6 +4,13 @@ class Booking < ApplicationRecord
   has_one :review
   validates :start_date, presence: true
   validates :end_date, presence: true
+  validate :end_date_cannot_come_before_start_date
   # validates :total_price, presence: true
   # validates :approval, presence: true
+
+  def end_date_cannot_come_before_start_date
+    if end_date.present? && end_date < start_date
+      errors.add(:end_date, "end date must come after start date")
+    end
+  end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -4,13 +4,22 @@ class Booking < ApplicationRecord
   has_one :review
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validate :end_date_cannot_come_before_start_date
+  validate :end_date_cannot_come_before_start_date, :booking_dates_cannot_be_in_the_past
   # validates :total_price, presence: true
   # validates :approval, presence: true
 
   def end_date_cannot_come_before_start_date
     if end_date.present? && end_date < start_date
       errors.add(:end_date, "end date must come after start date")
+    end
+  end
+
+  def booking_dates_cannot_be_in_the_past
+    if start_date.present? && start_date < Date.today
+      errors.add(:start_date, "You cannot make a booking in the past")
+    end
+    if end_date.present? && end_date < Date.today
+      errors.add(:end_date, "You cannot make a booking in the past")
     end
   end
 end


### PR DESCRIPTION
Wrote 2 custom validators for the booking model:
1) End_date cannot come before start-date (else error message gets returned)
2) Start or end date cannot be in the past (else error message gets returned)
See screenshots below
![image](https://user-images.githubusercontent.com/77265306/109997290-1a166480-7d21-11eb-9efc-2837ce3b74bc.png)
![image](https://user-images.githubusercontent.com/77265306/109997225-0965ee80-7d21-11eb-93d7-ed05491e7899.png)

